### PR TITLE
Draw inclinations from an isotropic distribution

### DIFF
--- a/fleck/core.py
+++ b/fleck/core.py
@@ -747,7 +747,7 @@ def generate_spots(min_latitude, max_latitude, spot_radius, n_spots,
     delta_latitude = max_latitude - min_latitude
     if n_inclinations is not None and inclinations is None:
         inc_stellar = np.arccos(np.random.rand(n_inclinations))
-        inc_stellar *= np.sign(np.random.uniform(-1, 1, n_inclinations))
+        inc_stellar *= np.sign(np.random.uniform(-1, 1, n_inclinations)) * u.deg
     else:
         n_inclinations = len(inclinations) if not inclinations.isscalar else 1
         inc_stellar = inclinations

--- a/fleck/core.py
+++ b/fleck/core.py
@@ -746,7 +746,8 @@ def generate_spots(min_latitude, max_latitude, spot_radius, n_spots,
     """
     delta_latitude = max_latitude - min_latitude
     if n_inclinations is not None and inclinations is None:
-        inc_stellar = (180*np.random.rand(n_inclinations) - 90) * u.deg
+        inc_stellar = np.arccos(np.random.rand(n_inclinations))
+        inc_stellar *= np.sign(np.random.uniform(-1, 1, n_inclinations))
     else:
         n_inclinations = len(inclinations) if not inclinations.isscalar else 1
         inc_stellar = inclinations


### PR DESCRIPTION
I think it's incorrect to draw inclinations at random from a uniform prior, since this overweights very low inclinations, which are extremely unlikely. That's because there are many ways to orient a star such that `i=90` (as the rotation vector can point in any direction along the plane of the sky) but only a *single* way to orient it such that `i=0` (the rotation vector must point along the direction to the observer). The distribution you want to sample from instead is an isotropic distribution, which is just the absolute value of the `sin` of the inclination. To draw from this distribution you just take the `arccos` of a uniform random variable. See [here](https://mathworld.wolfram.com/SpherePointPicking.html).

Here's a comparison of the current distribution (blue) and my proposed isotropic distribution (orange):

```python
incs_unif = (180*np.random.rand(n_inclinations) - 90) * np.pi / 180

incs_iso = np.arccos(np.random.rand(n_inclinations))
incs_iso *= np.sign(np.random.uniform(-1, 1, n_inclinations))

plt.hist(incs_unif, histtype="step", bins=30, lw=2, label="uniform", density=True)
plt.hist(incs_iso, histtype="step", bins=30, lw=2, label="isotropic", density=True)
plt.legend()
```

![image](https://user-images.githubusercontent.com/9323819/104851709-b0eba680-58c4-11eb-9822-4acd6824a680.png)

Hope this helps.