### PR TITLE
Small fixes and a bug?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - PYTHON_VERSION=3.7
+        - PYTHON_VERSION=3.8
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'

--- a/fleck/core.py
+++ b/fleck/core.py
@@ -236,13 +236,14 @@ class Star(object):
                                                    inc_stellar, times=times,
                                                    planet=planet,
                                                    time_ref=time_ref)
-
+        
         # Compute the distance of each spot from the stellar centroid, mask
         # any spots that are "behind" the star, in other words, x < 0
         r = np.ma.masked_array(np.hypot(tilted_spots.y.value,
                                         tilted_spots.z.value),
                                mask=tilted_spots.x.value < 0)
         ld = limb_darkening_normed(self.u_ld, r)
+
         # Compute the out-of-transit flux missing due to each spot
         f_spots = (np.pi * spot_radii**2 * (1 - self.spot_contrast) * ld *
                    np.sqrt(1 - r**2))
@@ -347,16 +348,17 @@ class Star(object):
         # Generate array of rotation matrices to rotate the spots about the
         # stellar rotation axis
         if times is None or (hasattr(times, '__len__') and times[0] is None):
-            rotate = rotation_matrix(self.phases[:, np.newaxis, np.newaxis],
+            rotate = rotation_matrix(self.phases[..., np.newaxis, np.newaxis],
                                      axis='z')
         else:
             if time_ref is None:
                 time_ref = 0
             rotational_phase = 2 * np.pi * ((times - time_ref) /
                                             self.rotation_period) * u.rad
-            rotate = rotation_matrix(rotational_phase[:, np.newaxis, np.newaxis],
+            rotate = rotation_matrix(rotational_phase[..., np.newaxis, np.newaxis],
                                      axis='z')
 
+        print(rotate.shape)
         rotated_spots = cartesian.transform(rotate)
 
         if planet is not None and hasattr(planet, 'lam'):

--- a/fleck/core.py
+++ b/fleck/core.py
@@ -130,7 +130,7 @@ def sort_plot_points(xy_coord, k0=0):
     n = len(xy_coord)
     distance_matrix = squareform(pdist(xy_coord, metric='euclidean'))
     mask = np.ones(n, dtype='bool')
-    sorted_order = np.zeros(n, dtype=np.int)
+    sorted_order = np.zeros(n, dtype=np.int32)
     indices = np.arange(n)
 
     i = 0
@@ -358,7 +358,6 @@ class Star(object):
             rotate = rotation_matrix(rotational_phase[..., np.newaxis, np.newaxis],
                                      axis='z')
 
-        print(rotate.shape)
         rotated_spots = cartesian.transform(rotate)
 
         if planet is not None and hasattr(planet, 'lam'):

--- a/fleck/core.py
+++ b/fleck/core.py
@@ -243,7 +243,6 @@ class Star(object):
                                         tilted_spots.z.value),
                                mask=tilted_spots.x.value < 0)
         ld = limb_darkening_normed(self.u_ld, r)
-
         # Compute the out-of-transit flux missing due to each spot
         f_spots = (np.pi * spot_radii**2 * (1 - self.spot_contrast) * ld *
                    np.sqrt(1 - r**2))
@@ -747,7 +746,8 @@ def generate_spots(min_latitude, max_latitude, spot_radius, n_spots,
     delta_latitude = max_latitude - min_latitude
     if n_inclinations is not None and inclinations is None:
         inc_stellar = np.arccos(np.random.rand(n_inclinations))
-        inc_stellar = inc_stellar * np.sign(np.random.uniform(-1, 1, n_inclinations)) * u.deg
+        inc_stellar = inc_stellar * np.sign(np.random.uniform(-1, 1, n_inclinations)) * u.rad
+        inc_stellar = inc_stellar.to(u.deg)
     else:
         n_inclinations = len(inclinations) if not inclinations.isscalar else 1
         inc_stellar = inclinations

--- a/fleck/core.py
+++ b/fleck/core.py
@@ -747,7 +747,7 @@ def generate_spots(min_latitude, max_latitude, spot_radius, n_spots,
     delta_latitude = max_latitude - min_latitude
     if n_inclinations is not None and inclinations is None:
         inc_stellar = np.arccos(np.random.rand(n_inclinations))
-        inc_stellar *= np.sign(np.random.uniform(-1, 1, n_inclinations)) * u.deg
+        inc_stellar = inc_stellar * np.sign(np.random.uniform(-1, 1, n_inclinations)) * u.deg
     else:
         n_inclinations = len(inclinations) if not inclinations.isscalar else 1
         inc_stellar = inclinations


### PR DESCRIPTION
Hi @bmorris3,

first of all, thanks for this nicely documented lean piece of programming! _fleck_ turns out to work great with flares, too! While trying out the software, I stumbled over a few small issues, mostly cosmetic, which I suggest incorporating in a future of release of _fleck_:

**First**, I suggest, bumping up fleck to at least Python 3.8.

**Second**, I suggest following adjustments to `core.py`:

- `np.int` >>> `np.int32` to remove a deprecation warning from numpy
-  `self.phases[:, np.newaxis, np.newaxis]` >>>  `self.phases[..., np.newaxis, np.newaxis]` so that fleck works with higher dimensional input (e.g., if accommodating dynamic flaring regions instead of static spots)
- convert `inc_stellar` from rad to deg in `generate_spots` to make it more consistent with input variables that are given in deg, e.g. `min_latitude` and `max_latitude`.
- removing inplace multiplication in  `generate_spots` because that, for some reason, does not work with astropy units (this is something a have seen failing in one of the recent travis runs, so I don't think that's a local issue)

Cheers, Ekaterina
 
