### PR TITLE
Removing print statement from core.py's Star.plot function

### DIFF
--- a/fleck/core.py
+++ b/fleck/core.py
@@ -646,7 +646,6 @@ class Star(object):
                     np.squeeze(spot_radii[i, 0])
                 ])
 
-                print('args', ellipse_centroid, ellipse_axes, angle)
                 spot = ellipse(ellipse_centroid, ellipse_axes,
                                np.degrees(angle))
 


### PR DESCRIPTION
There was an annoying print statement that was called everytime the `fleck.Star.plot` function was called, which I assume was initially added for testing purposes but was never removed. I've removed the print statement, but if you want to keep it can you add a `verbose` kind of argument to the function to enable/disable this print statement?