### PR TITLE
numpy maxpin for compatibility with batman

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ docs = [
     "emcee",
     "corner",
     "pybind11>=2.12",
+    "numpy<2.0"
 ]
 jax = [
     "jax[cpu]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 dependencies = [
   "astropy",
-  "numpy",
+  "numpy<2",
   "scipy",
   "shapely",
   "matplotlib"
@@ -38,7 +38,6 @@ docs = [
     "emcee",
     "corner",
     "pybind11>=2.12",
-    "numpy<2.0"
 ]
 jax = [
     "jax[cpu]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = { file = "LICENSE", content-type = "text/plain" }
 authors = [
   { name = "Brett Morris", email = "morrisbrettm@gmail.com" },
 ]
+# require numpy < 2 until batman supports 2.x+
 dependencies = [
   "astropy",
   "numpy<2",
@@ -37,7 +38,6 @@ docs = [
     "healpy",
     "emcee",
     "corner",
-    "pybind11>=2.12",
 ]
 jax = [
     "jax[cpu]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ docs = [
     "healpy",
     "emcee",
     "corner",
+    "pybind11>=2.12",
 ]
 jax = [
     "jax[cpu]",


### PR DESCRIPTION
Seems that batman is incompatible with numpy 2. Maxpinning numpy in this PR until they're compatible.